### PR TITLE
ported acceptance tests to use the latest version of the api supporte…

### DIFF
--- a/brocadevtm/resource_global_settings_test.go
+++ b/brocadevtm/resource_global_settings_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/sky-uk/go-brocade-vtm/api"
-	"testing"
 	"os"
+	"testing"
 )
 
 func TestAccBrocadeVTMResourceGlobalSettings(t *testing.T) {

--- a/brocadevtm/resource_global_settings_test.go
+++ b/brocadevtm/resource_global_settings_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/sky-uk/go-brocade-vtm/api"
 	"testing"
+	"sort"
 )
 
 func TestAccBrocadeVTMResourceGlobalSettings(t *testing.T) {
@@ -69,7 +70,11 @@ func testAccBrocadeVTMGlobalSettingsCheckDestroy(state *terraform.State) error {
 			return nil
 		}
 		gs := make(map[string]interface{})
-		err := client.GetByURL("/api/tm/3.8/config/active/global_settings", &gs)
+
+		apiVersions := client.VersionsSupported
+		sort.Sort(sort.Reverse(sort.StringSlice(apiVersions)))
+		latestVersion := apiVersions[0]
+		err := client.GetByURL("/api/tm/"+latestVersion+"/config/active/global_settings", &gs)
 		if err != nil {
 			return nil
 		}
@@ -90,8 +95,11 @@ func testAccBrocadeVTMGlobalSettingsExists() resource.TestCheckFunc {
 
 		config := testAccProvider.Meta().(map[string]interface{})
 		client := config["jsonClient"].(*api.Client)
+		apiVersions := client.VersionsSupported
+		sort.Sort(sort.Reverse(sort.StringSlice(apiVersions)))
+		latestVersion := apiVersions[0]
 		gs := make(map[string]interface{})
-		err := client.GetByURL("/api/tm/3.8/config/active/global_settings", &gs)
+		err := client.GetByURL("/api/tm/"+latestVersion+"/config/active/global_settings", &gs)
 		if err != nil {
 			return fmt.Errorf("Error getting global settings: %+v", err)
 		}

--- a/brocadevtm/resource_global_settings_test.go
+++ b/brocadevtm/resource_global_settings_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/sky-uk/go-brocade-vtm/api"
 	"testing"
-	"sort"
+	"os"
 )
 
 func TestAccBrocadeVTMResourceGlobalSettings(t *testing.T) {
@@ -71,10 +71,11 @@ func testAccBrocadeVTMGlobalSettingsCheckDestroy(state *terraform.State) error {
 		}
 		gs := make(map[string]interface{})
 
-		apiVersions := client.VersionsSupported
-		sort.Sort(sort.Reverse(sort.StringSlice(apiVersions)))
-		latestVersion := apiVersions[0]
-		err := client.GetByURL("/api/tm/"+latestVersion+"/config/active/global_settings", &gs)
+		var usedVersion = "3.8"
+		if os.Getenv("BROCADEVTM_API_VERSION") != "" {
+			usedVersion = os.Getenv("BROCADEVTM_API_VERSION")
+		}
+		err := client.GetByURL("/api/tm/"+usedVersion+"/config/active/global_settings", &gs)
 		if err != nil {
 			return nil
 		}
@@ -95,11 +96,12 @@ func testAccBrocadeVTMGlobalSettingsExists() resource.TestCheckFunc {
 
 		config := testAccProvider.Meta().(map[string]interface{})
 		client := config["jsonClient"].(*api.Client)
-		apiVersions := client.VersionsSupported
-		sort.Sort(sort.Reverse(sort.StringSlice(apiVersions)))
-		latestVersion := apiVersions[0]
+		var usedVersion = "3.8"
+		if os.Getenv("BROCADEVTM_API_VERSION") != "" {
+			usedVersion = os.Getenv("BROCADEVTM_API_VERSION")
+		}
 		gs := make(map[string]interface{})
-		err := client.GetByURL("/api/tm/"+latestVersion+"/config/active/global_settings", &gs)
+		err := client.GetByURL("/api/tm/"+usedVersion+"/config/active/global_settings", &gs)
 		if err != nil {
 			return fmt.Errorf("Error getting global settings: %+v", err)
 		}

--- a/brocadevtm/resource_monitor_test.go
+++ b/brocadevtm/resource_monitor_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"os"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/sky-uk/go-brocade-vtm/api"
-	"sort"
 )
 
 func TestAccBrocadeVTMMonitorBasic(t *testing.T) {
@@ -16,13 +16,12 @@ func TestAccBrocadeVTMMonitorBasic(t *testing.T) {
 	randomInt := acctest.RandInt()
 	monitorName := fmt.Sprintf("acctest_brocadevtm_monitor-%d", randomInt)
 	monitorResourceName := "brocadevtm_monitor.acctest"
-
 	fmt.Printf("\n\nMonitor Name is %s.\n\n", monitorName)
-	config := testAccProvider.Meta().(map[string]interface{})
+	var usedVersion = "3.8"
+	if os.Getenv("BROCADEVTM_API_VERSION") != "" {
+		usedVersion = os.Getenv("BROCADEVTM_API_VERSION")
+	}
 
-	apiVersions := config["jsonClient"].(*api.Client).VersionsSupported
-	sort.Sort(sort.Reverse(sort.StringSlice(apiVersions)))
-	usedVersion := apiVersions[0]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/brocadevtm/resource_monitor_test.go
+++ b/brocadevtm/resource_monitor_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/sky-uk/go-brocade-vtm/api"
+	"sort"
 )
 
 func TestAccBrocadeVTMMonitorBasic(t *testing.T) {
@@ -18,6 +18,11 @@ func TestAccBrocadeVTMMonitorBasic(t *testing.T) {
 	monitorResourceName := "brocadevtm_monitor.acctest"
 
 	fmt.Printf("\n\nMonitor Name is %s.\n\n", monitorName)
+	config := testAccProvider.Meta().(map[string]interface{})
+
+	apiVersions := config["jsonClient"].(*api.Client).VersionsSupported
+	sort.Sort(sort.Reverse(sort.StringSlice(apiVersions)))
+	usedVersion := apiVersions[0]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -28,7 +33,7 @@ func TestAccBrocadeVTMMonitorBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBrocadeVTMMonitorInvalidName(),
-				ExpectError: regexp.MustCompile(`BrocadeVTM Monitor error whilst creating ../virtual_servers/some_random_virtual_server: The path '/api/tm/3.8/config/active/monitors/../virtual_servers/some_random_virtual_server' is invalid`),
+				ExpectError: regexp.MustCompile(`BrocadeVTM Monitor error whilst creating ../virtual_servers/some_random_virtual_server: The path '/api/tm/`+usedVersion+`/config/active/monitors/../virtual_servers/some_random_virtual_server' is invalid`),
 			},
 			{
 				Config: testAccBrocadeVTMMonitorCreateTemplate(monitorName),

--- a/brocadevtm/resource_monitor_test.go
+++ b/brocadevtm/resource_monitor_test.go
@@ -2,13 +2,13 @@ package brocadevtm
 
 import (
 	"fmt"
-	"regexp"
-	"testing"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"os"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/sky-uk/go-brocade-vtm/api"
+	"os"
+	"regexp"
+	"testing"
 )
 
 func TestAccBrocadeVTMMonitorBasic(t *testing.T) {
@@ -22,7 +22,6 @@ func TestAccBrocadeVTMMonitorBasic(t *testing.T) {
 		usedVersion = os.Getenv("BROCADEVTM_API_VERSION")
 	}
 
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -32,7 +31,7 @@ func TestAccBrocadeVTMMonitorBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBrocadeVTMMonitorInvalidName(),
-				ExpectError: regexp.MustCompile(`BrocadeVTM Monitor error whilst creating ../virtual_servers/some_random_virtual_server: The path '/api/tm/`+usedVersion+`/config/active/monitors/../virtual_servers/some_random_virtual_server' is invalid`),
+				ExpectError: regexp.MustCompile(`BrocadeVTM Monitor error whilst creating ../virtual_servers/some_random_virtual_server: The path '/api/tm/` + usedVersion + `/config/active/monitors/../virtual_servers/some_random_virtual_server' is invalid`),
 			},
 			{
 				Config: testAccBrocadeVTMMonitorCreateTemplate(monitorName),


### PR DESCRIPTION
…d instead of having it hardcoded as a string in the tests and acceptance criteria